### PR TITLE
Minor updates to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ of `dart` executable in your `PATH`.
 When both the `dart` executable and `out/protoc-gen-dart` are in the
 `PATH` the protocol buffer compiler can be invoked to generate like this:
 
-    $ protoc --out_dart=. test.proto
+    $ protoc --dart_out=. test.proto
 
 ### Options to control the generated Dart code
 


### PR DESCRIPTION
I made the build instructions a bit easier to follow and added `pub install` step before running the build script.
Still not the best instructions in the world, but a step in the right direction :)
