### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ option. If the script is called `dart-plugin` run `protoc` like this:
 Useful references
 -----------------
 
-* [Main Dart site](http://www.dartlang.org)
-* [Main protobuf site](https://code.google.com/p/protobuf)
+* [Main Dart site](https://www.dartlang.org/)
+* [Main protobuf site](https://github.com/google/protobuf)
 * [Protobuf runtime support project](https://github.com/dart-lang/dart-protobuf)
 * [DartEditor download](http://www.dartlang.org)
-* [Pub documentation](http://pub.dartlang.org/doc)
+* [Pub documentation](https://www.dartlang.org/tools/pub/get-started.html)


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Corrected URLs 
Was | Now 
--- | --- 
http://pub.dartlang.org/doc | https://www.dartlang.org/tools/pub/get-started.html 
http://www.dartlang.org | https://www.dartlang.org/ 
https://code.google.com/p/protobuf | https://github.com/google/protobuf 
