### PR TITLE
Ignore the following lint errors in generated proto code:

### DIFF
--- a/lib/file_generator.dart
+++ b/lib/file_generator.dart
@@ -483,6 +483,8 @@ import 'package:protobuf/protobuf.dart';
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library $libraryName;
 ''');
   }

--- a/test/file_generator_test.dart
+++ b/test/file_generator_test.dart
@@ -76,6 +76,8 @@ void main() {
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test;
 
 // ignore: UNUSED_SHOWN_NAME
@@ -138,6 +140,8 @@ class _ReadonlyPhoneNumber extends PhoneNumber with ReadonlyMessageMixin {}
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test_pbjson;
 
 const PhoneNumber$json = const {
@@ -165,6 +169,8 @@ const PhoneNumber$json = const {
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test;
 
 // ignore: UNUSED_SHOWN_NAME
@@ -177,6 +183,8 @@ export 'test.pbenum.dart';
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test_pbenum;
 
 // ignore: UNUSED_SHOWN_NAME
@@ -223,6 +231,8 @@ class PhoneType extends ProtobufEnum {
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test_pbjson;
 
 const PhoneType$json = const {
@@ -252,6 +262,8 @@ const PhoneType$json = const {
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library pb_library_test;
 
 // ignore: UNUSED_SHOWN_NAME
@@ -277,6 +289,8 @@ import 'package:protobuf/protobuf.dart';
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test;
 
 // ignore: UNUSED_SHOWN_NAME
@@ -312,6 +326,8 @@ import 'package:protobuf/protobuf.dart';
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test;
 
 // ignore: UNUSED_SHOWN_NAME
@@ -360,6 +376,8 @@ class TestApi {
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test_pbserver;
 
 import 'dart:async';
@@ -426,6 +444,8 @@ abstract class TestServiceBase extends GeneratedService {
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test;
 
 // ignore: UNUSED_SHOWN_NAME
@@ -483,6 +503,8 @@ class _ReadonlyM extends M with ReadonlyMessageMixin {}
 ///
 //  Generated code. Do not modify.
 ///
+// @ignoreProblemForFile non_constant_identifier_names
+// @ignoreProblemForFile library_prefixes
 library test_pbjson;
 
 const M$json = const {


### PR DESCRIPTION
* [non_constant_identifier_names]
* [library_prefixes]

The Dart proto generator uses underscores, which would normally
trigger lint errors for the aforementioned lints, but we do so
intentionally, so ignoring them is safe.