### PR TITLE
Enable executable for pub global usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ When both the `dart` executable and `out/protoc-gen-dart` are in the
 
     $ protoc --dart_out=. test.proto
 
+### Optionally using `pub global`
+
+    $ pub global activate -sgit https://github.com/dart-lang/dart-protoc-plugin
+
+And then add `.pub-cache/bin` in your home dir to your `PATH` if you haven't already.
+
 ### Options to control the generated Dart code
 
 The protocol buffer compiler accepts options for each plugin. For the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,3 +12,5 @@ dependencies:
 dev_dependencies:
   browser: any
   test: ^0.12.0
+executables:
+  protoc-gen-dart: protoc_plugin


### PR DESCRIPTION
Simplifies installation by automatically installing the executable in the pub global bin directory.