### PR TITLE
Don't use readlink in bin/protoc-gen-dart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ When both the `dart` executable and `bin/protoc-gen-dart` are in the
 
 And then add `.pub-cache/bin` in your home dir to your `PATH` if you haven't already.
 
+This will activate the latest published version of the plugin. If you wish to use a
+local working copy, use
+
+    $ pub global activate -s path <path/to/your/dart-protoc-plugin>
+
+
 ### Options to control the generated Dart code
 
 The protocol buffer compiler accepts options for each plugin. For the

--- a/bin/protoc-gen-dart
+++ b/bin/protoc-gen-dart
@@ -1,3 +1,3 @@
 #!/bin/bash
-BINDIR=$(dirname "$(readlink -f "$0")")
+BINDIR=$(dirname "$0")
 dart "$BINDIR/protoc_plugin.dart" -c "$@"


### PR DESCRIPTION
It doesn't work on macOS, unfortunately. The main side-effect of this change is that making a symlink to `bin/protoc-gen-dart` won't work anymore, since it won't correctly resolve it's directory.

The preferred way to run the plugin is using `pub global activate` or explicitly passing the path on the protoc commmand line, so this is mainly for development.

Fixes #77.