### PR TITLE
Fix a couple of style issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ build-plugin: $(PLUGIN_PATH)
 
 update-pregenerated: $(PLUGIN_PATH) $(PREGENERATED_SRCS)
 	protoc --dart_out=lib/src -Iprotos --plugin=protoc-gen-dart=$(realpath $(PLUGIN_PATH)) $(PREGENERATED_SRCS)
+	rm lib/src/descriptor.pb{json,server}.dart
+	rm lib/src/dart_options.pb{enum,json,server}.dart
+	rm lib/src/plugin.pb{enum,json,server}.dart
+	dartfmt -w lib/src
 
 protos: $(PLUGIN_PATH) $(TEST_PROTO_LIBS)
 	mkdir -p benchmark/lib/generated

--- a/lib/enum_generator.dart
+++ b/lib/enum_generator.dart
@@ -89,7 +89,7 @@ class EnumGenerator extends ProtobufContainer {
       out.println('static ${classname} valueOf(int value) =>'
           ' _byValue[value] as ${classname};');
       out.addBlock('static void $checkItem($classname v) {', '}', () {
-        out.println('if (v is !$classname)'
+        out.println('if (v is! $classname)'
             " checkItemFailed(v, '$classname');");
       });
       out.println();

--- a/lib/file_generator.dart
+++ b/lib/file_generator.dart
@@ -241,16 +241,16 @@ class FileGenerator extends ProtobufContainer {
       [OutputConfiguration config = const DefaultOutputConfiguration()]) {
     _writeLibraryHeading(out);
 
+    // We only add the dart:async import if there are generic client API
+    // generators for services in the FileDescriptorProto.
+    if (clientApiGenerators.isNotEmpty) {
+      out.println("import 'dart:async';");
+    }
+
     // Make sure any other symbols in dart:core don't cause name conflicts with
     // protobuf classes that have the same name.
     out.println("// ignore: UNUSED_SHOWN_NAME\n"
-        "import 'dart:core' show int, bool, double, String, List, override;");
-
-    // We only add the dart:async import if there are services in the
-    // FileDescriptorProto.
-    if (descriptor.service.isNotEmpty) {
-      out.println("import 'dart:async';\n");
-    }
+        "import 'dart:core' show int, bool, double, String, List, override;\n");
 
     if (_needsFixnumImport) {
       out.println("import 'package:fixnum/fixnum.dart';");

--- a/lib/message_generator.dart
+++ b/lib/message_generator.dart
@@ -253,7 +253,7 @@ class MessageGenerator extends ProtobufContainer {
       });
       out.println('static ${classname} _defaultInstance;');
       out.addBlock('static void $checkItem($classname v) {', '}', () {
-        out.println('if (v is !$classname)'
+        out.println('if (v is! $classname)'
             " checkItemFailed(v, '$classname');");
       });
       generateFieldsAccessorsMutators(out);

--- a/lib/src/dart_options.pb.dart
+++ b/lib/src/dart_options.pb.dart
@@ -7,6 +7,7 @@ library dart_options_dart_options;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 import 'package:protobuf/protobuf.dart';
 
 class DartMixin extends GeneratedMessage {

--- a/lib/src/descriptor.pb.dart
+++ b/lib/src/descriptor.pb.dart
@@ -7,6 +7,7 @@ library google.protobuf_descriptor;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';
 

--- a/lib/src/plugin.pb.dart
+++ b/lib/src/plugin.pb.dart
@@ -7,6 +7,7 @@ library google.protobuf.compiler_plugin;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 import 'package:protobuf/protobuf.dart';
 
 import 'descriptor.pb.dart' as google$protobuf;

--- a/test/enum_generator_test.dart
+++ b/test/enum_generator_test.dart
@@ -29,7 +29,7 @@ class PhoneType extends ProtobufEnum {
   static final Map<int, dynamic> _byValue = ProtobufEnum.initByValue(values);
   static PhoneType valueOf(int value) => _byValue[value] as PhoneType;
   static void $checkItem(PhoneType v) {
-    if (v is !PhoneType) checkItemFailed(v, 'PhoneType');
+    if (v is! PhoneType) checkItemFailed(v, 'PhoneType');
   }
 
   const PhoneType._(int v, String n) : super(v, n);

--- a/test/file_generator_test.dart
+++ b/test/file_generator_test.dart
@@ -82,6 +82,7 @@ library test;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 import 'package:protobuf/protobuf.dart';
 
 class PhoneNumber extends GeneratedMessage {
@@ -104,7 +105,7 @@ class PhoneNumber extends GeneratedMessage {
   }
   static PhoneNumber _defaultInstance;
   static void $checkItem(PhoneNumber v) {
-    if (v is !PhoneNumber) checkItemFailed(v, 'PhoneNumber');
+    if (v is! PhoneNumber) checkItemFailed(v, 'PhoneNumber');
   }
 
   String get number => $_get(0, 1, '');
@@ -175,6 +176,7 @@ library test;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 export 'test.pbenum.dart';
 
 ''';
@@ -207,7 +209,7 @@ class PhoneType extends ProtobufEnum {
   static final Map<int, dynamic> _byValue = ProtobufEnum.initByValue(values);
   static PhoneType valueOf(int value) => _byValue[value] as PhoneType;
   static void $checkItem(PhoneType v) {
-    if (v is !PhoneType) checkItemFailed(v, 'PhoneType');
+    if (v is! PhoneType) checkItemFailed(v, 'PhoneType');
   }
 
   const PhoneType._(int v, String n) : super(v, n);
@@ -268,6 +270,7 @@ library pb_library_test;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 import 'package:protobuf/protobuf.dart';
 
 ''';
@@ -295,6 +298,7 @@ library test;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 import 'package:fixnum/fixnum.dart';
 import 'package:protobuf/protobuf.dart';
 
@@ -330,9 +334,9 @@ import 'package:protobuf/protobuf.dart';
 // ignore_for_file: library_prefixes
 library test;
 
+import 'dart:async';
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
-import 'dart:async';
 
 import 'package:protobuf/protobuf.dart';
 
@@ -354,7 +358,7 @@ class Empty extends GeneratedMessage {
   }
   static Empty _defaultInstance;
   static void $checkItem(Empty v) {
-    if (v is !Empty) checkItemFailed(v, 'Empty');
+    if (v is! Empty) checkItemFailed(v, 'Empty');
   }
 }
 
@@ -450,7 +454,6 @@ library test;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
-import 'dart:async';
 
 import 'package:protobuf/protobuf.dart';
 
@@ -472,7 +475,7 @@ class Empty extends GeneratedMessage {
   }
   static Empty _defaultInstance;
   static void $checkItem(Empty v) {
-    if (v is !Empty) checkItemFailed(v, 'Empty');
+    if (v is! Empty) checkItemFailed(v, 'Empty');
   }
 }
 
@@ -680,6 +683,7 @@ library test;
 
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
+
 import 'package:protobuf/protobuf.dart';
 
 import 'package1.pb.dart' as p1;
@@ -706,7 +710,7 @@ class M extends GeneratedMessage {
   }
   static M _defaultInstance;
   static void $checkItem(M v) {
-    if (v is !M) checkItemFailed(v, 'M');
+    if (v is! M) checkItemFailed(v, 'M');
   }
 
   M get m => $_get(0, 1, null);

--- a/test/indenting_writer_test.dart
+++ b/test/indenting_writer_test.dart
@@ -17,9 +17,7 @@ void main() {
       out.println('second;');
     });
 
-    expect(
-        out.toString(),
-        '''
+    expect(out.toString(), '''
 class test {
   first;
 

--- a/test/message_generator_test.dart
+++ b/test/message_generator_test.dart
@@ -32,7 +32,7 @@ class PhoneNumber_PhoneType extends ProtobufEnum {
   static final Map<int, dynamic> _byValue = ProtobufEnum.initByValue(values);
   static PhoneNumber_PhoneType valueOf(int value) => _byValue[value] as PhoneNumber_PhoneType;
   static void $checkItem(PhoneNumber_PhoneType v) {
-    if (v is !PhoneNumber_PhoneType) checkItemFailed(v, 'PhoneNumber_PhoneType');
+    if (v is! PhoneNumber_PhoneType) checkItemFailed(v, 'PhoneNumber_PhoneType');
   }
 
   const PhoneNumber_PhoneType._(int v, String n) : super(v, n);
@@ -61,7 +61,7 @@ class PhoneNumber extends GeneratedMessage {
   }
   static PhoneNumber _defaultInstance;
   static void $checkItem(PhoneNumber v) {
-    if (v is !PhoneNumber) checkItemFailed(v, 'PhoneNumber');
+    if (v is! PhoneNumber) checkItemFailed(v, 'PhoneNumber');
   }
 
   String get number => $_get(0, 1, '');


### PR DESCRIPTION
Use 'is!' instead of 'is !'.

Move 'dart:async' import above 'dart:core' import to satisfy import order lint, and only import 'dart:async' in .pb.dart files if there are legacy "generic" RPC client generators.

Remove unnecesary files when re-generating descriptor, plugin, and dart_options, and format generated files.