### PR TITLE
Update gRPC client stub generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.6 - 2017-08-22
+
+* Updated gRPC client stub generation to produce code matching latest changes to
+  dart-lang/dart-grpc.
+
 ## 0.7.5 - 2017-08-04
 
 * Use real generic syntax instead of comment-based.

--- a/lib/grpc_generator.dart
+++ b/lib/grpc_generator.dart
@@ -111,14 +111,14 @@ class GrpcServiceGenerator {
   }
 
   void _generateClient(IndentingWriter out) {
-    out.addBlock('class $_clientClassname {', '}', () {
-      out.println('final ClientChannel _channel;');
-      out.println();
+    out.addBlock('class $_clientClassname extends Client {', '}', () {
       for (final method in _methods) {
         method.generateClientMethodDescriptor(out);
       }
       out.println();
-      out.println('$_clientClassname(this._channel);');
+      out.println(
+          '$_clientClassname(ClientChannel channel, {CallOptions options})');
+      out.println('    : super(channel, options: options);');
       for (final method in _methods) {
         method.generateClientStub(out);
       }
@@ -222,7 +222,7 @@ class _GrpcMethod {
         '$_clientReturnType $_dartName($_argumentType request, {CallOptions options}) {',
         '}', () {
       out.println(
-          'final call = new ClientCall(_channel, _\$$_dartName, options: options);');
+          'final call = \$createCall(_\$$_dartName, options: options);');
       if (_clientStreaming) {
         out.println('request.pipe(call.request);');
       } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 0.7.5
+version: 0.7.6
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/dart-protoc-plugin

--- a/test/file_generator_test.dart
+++ b/test/file_generator_test.dart
@@ -523,9 +523,7 @@ import 'package:grpc/grpc.dart';
 import 'test.pb.dart';
 export 'test.pb.dart';
 
-class TestClient {
-  final ClientChannel _channel;
-
+class TestClient extends Client {
   static final _$unary = new ClientMethod<Input, Output>(
       '/Test/Unary',
       (Input value) => value.writeToBuffer(),
@@ -543,10 +541,11 @@ class TestClient {
       (Input value) => value.writeToBuffer(),
       (List<int> value) => new Output.fromBuffer(value));
 
-  TestClient(this._channel);
+  TestClient(ClientChannel channel, {CallOptions options})
+      : super(channel, options: options);
 
   ResponseFuture<Output> unary(Input request, {CallOptions options}) {
-    final call = new ClientCall(_channel, _$unary, options: options);
+    final call = $createCall(_$unary, options: options);
     call.request
       ..add(request)
       ..close();
@@ -555,13 +554,13 @@ class TestClient {
 
   ResponseFuture<Output> clientStreaming(Stream<Input> request,
       {CallOptions options}) {
-    final call = new ClientCall(_channel, _$clientStreaming, options: options);
+    final call = $createCall(_$clientStreaming, options: options);
     request.pipe(call.request);
     return new ResponseFuture(call);
   }
 
   ResponseStream<Output> serverStreaming(Input request, {CallOptions options}) {
-    final call = new ClientCall(_channel, _$serverStreaming, options: options);
+    final call = $createCall(_$serverStreaming, options: options);
     call.request
       ..add(request)
       ..close();
@@ -570,7 +569,7 @@ class TestClient {
 
   ResponseStream<Output> bidirectional(Stream<Input> request,
       {CallOptions options}) {
-    final call = new ClientCall(_channel, _$bidirectional, options: options);
+    final call = $createCall(_$bidirectional, options: options);
     request.pipe(call.request);
     return new ResponseStream(call);
   }


### PR DESCRIPTION
Client stubs should extend Client and use $createCall to create
ClientCall objects. The super-class will handle merging the per-client
call options with the per-RPC options. And make it easier to refactor
call generation code.