### PR TITLE
Updated gRPC client stub generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 * Avoid name clashes between import prefix and field names.
 * Avoid name clashes between generated enum and extension class names.
+* Updated gRPC client stub generation to match latest changes to dart-lang/grpc-dart.
 
 ## 0.7.6 - 2017-08-22
 
 * Updated gRPC client stub generation to produce code matching latest changes to
-  dart-lang/dart-grpc.
+  dart-lang/grpc-dart.
 
 ## 0.7.5 - 2017-08-04
 

--- a/lib/grpc_generator.dart
+++ b/lib/grpc_generator.dart
@@ -221,13 +221,10 @@ class _GrpcMethod {
     out.addBlock(
         '$_clientReturnType $_dartName($_argumentType request, {CallOptions options}) {',
         '}', () {
+      final requestStream =
+          _clientStreaming ? 'request' : 'new Stream.fromIterable([request])';
       out.println(
-          'final call = \$createCall(_\$$_dartName, options: options);');
-      if (_clientStreaming) {
-        out.println('request.pipe(call.request);');
-      } else {
-        out.println('call.request..add(request)..close();');
-      }
+          'final call = \$createCall(_\$$_dartName, $requestStream, options: options);');
       if (_serverStreaming) {
         out.println('return new ResponseStream(call);');
       } else {

--- a/test/file_generator_test.dart
+++ b/test/file_generator_test.dart
@@ -534,32 +534,27 @@ class TestClient extends Client {
       : super(channel, options: options);
 
   ResponseFuture<Output> unary(Input request, {CallOptions options}) {
-    final call = $createCall(_$unary, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(_$unary, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseFuture(call);
   }
 
   ResponseFuture<Output> clientStreaming(Stream<Input> request,
       {CallOptions options}) {
-    final call = $createCall(_$clientStreaming, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$clientStreaming, request, options: options);
     return new ResponseFuture(call);
   }
 
   ResponseStream<Output> serverStreaming(Input request, {CallOptions options}) {
-    final call = $createCall(_$serverStreaming, options: options);
-    call.request
-      ..add(request)
-      ..close();
+    final call = $createCall(
+        _$serverStreaming, new Stream.fromIterable([request]),
+        options: options);
     return new ResponseStream(call);
   }
 
   ResponseStream<Output> bidirectional(Stream<Input> request,
       {CallOptions options}) {
-    final call = $createCall(_$bidirectional, options: options);
-    request.pipe(call.request);
+    final call = $createCall(_$bidirectional, request, options: options);
     return new ResponseStream(call);
   }
 }


### PR DESCRIPTION
The $createCall method now takes the request stream as argument, instead of providing a StreamSink on the ClientCall object.