### PR TITLE
Dart 2 Fixes

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,10 +8,9 @@ environment:
 dependencies:
   fixnum: ^0.10.5
   path: ^1.0.0
-  protobuf: ^0.8.0
+  protobuf: ^0.9.0
   dart_style: ^1.0.6
 dev_dependencies:
-  browser: any
-  test: ^0.12.0
+  test: ^1.3.0
 executables:
   protoc-gen-dart: protoc_plugin

--- a/test/extension_test.dart
+++ b/test/extension_test.dart
@@ -146,7 +146,7 @@ void main() {
 
   test('can extend a message with a message field with a different type', () {
     expect(Non_nested_extension.nonNestedExtension.makeDefault(),
-        new isInstanceOf<MyNonNestedExtension>());
+        new TypeMatcher<MyNonNestedExtension>());
     expect(Non_nested_extension.nonNestedExtension.name, 'nonNestedExtension');
   });
 

--- a/test/generated_message_test.dart
+++ b/test/generated_message_test.dart
@@ -24,7 +24,7 @@ import 'test_util.dart';
 
 void main() {
   final throwsInvalidProtocolBufferException =
-      throwsA(new isInstanceOf<InvalidProtocolBufferException>());
+      throwsA(new TypeMatcher<InvalidProtocolBufferException>());
   test('testProtosShareRepeatedArraysIfDidntChange', () {
     TestAllTypes value1 = new TestAllTypes()
       ..repeatedInt32.add(100)
@@ -223,7 +223,7 @@ void main() {
 
   test('testEnumInterface', () {
     expect(
-        new TestAllTypes().defaultNestedEnum, new isInstanceOf<ProtobufEnum>());
+        new TestAllTypes().defaultNestedEnum, new TypeMatcher<ProtobufEnum>());
   });
 
   test('testEnumMap', () {

--- a/test/protoc_options_test.dart
+++ b/test/protoc_options_test.dart
@@ -16,7 +16,7 @@ void main() {
       if (parameter != null) request.parameter = parameter;
       var response = new CodeGeneratorResponse();
       var options = parseGenerationOptions(request, response);
-      expect(options, new isInstanceOf<GenerationOptions>());
+      expect(options, new TypeMatcher<GenerationOptions>());
       expect(response.error, '');
     }
 

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 import '../out/protos/google/protobuf/unittest_import.pb.dart';
 import '../out/protos/google/protobuf/unittest.pb.dart';
 
-final Matcher throwsATypeError = throwsA(new isInstanceOf<TypeError>());
+final Matcher throwsATypeError = throwsA(new TypeMatcher<TypeError>());
 
 Int64 make64(lo, [hi = null]) {
   if (hi == null) hi = lo < 0 ? -1 : 0;


### PR DESCRIPTION
After the official release of Dart 2, the protoc_plugin cannot be activated due to the following error:
```
Because protoc_plugin <=0.8.0 requires SDK version >=1.13.0
  <2.0.0-dev.infinity and protoc_plugin >=0.8.0+1 depends on protobuf ^0.8.0,
  every version of protoc_plugin requires protobuf ^0.8.0.
So, because protobuf >=0.2.0 <=0.9.0 requires SDK version >=0.7.5 <2.0.0-∞ and
  pub global activate depends on protoc_plugin any, version solving failed.
```
This pull-request upgrades the `protobuf` and `test` packages to satisfy all of Dart 2 required fixes and have the protoc_plugin deps be resolvable and the plugin itself activatable. The upgrade introduced deprecation notices to popup, so those got fixed along.

I've ran `make` and `make run-tests` before sending this PR, and both commands have exited successfully with no errors.