### PR TITLE
Use $async as prefix for dart:async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 0.10.5
+
+* Generated files now import `dart:async` with a prefix to prevent name
+  collisions.
+
 ## 0.10.4
 
-* Change the fully qualfiied message name of generated messages to use
+* Change the fully qualified message name of generated messages to use
   `BuilderInfo.qualifiedMessageName`.
   Requires package:protobuf version 0.10.4 or newer.
 

--- a/lib/client_generator.dart
+++ b/lib/client_generator.dart
@@ -33,7 +33,7 @@ class ClientApiGenerator {
     var inputType = service._getDartClassName(m.inputType);
     var outputType = service._getDartClassName(m.outputType);
     out.addBlock(
-        'Future<$outputType> $methodName('
+        '\$async.Future<$outputType> $methodName('
         '$_protobufImportPrefix.ClientContext ctx, $inputType request) {',
         '}', () {
       out.println('var emptyResponse = new $outputType();');

--- a/lib/file_generator.dart
+++ b/lib/file_generator.dart
@@ -239,7 +239,8 @@ class FileGenerator extends ProtobufContainer {
     // We only add the dart:async import if there are generic client API
     // generators for services in the FileDescriptorProto.
     if (clientApiGenerators.isNotEmpty) {
-      out.println("import 'dart:async';");
+      out.println("// ignore: UNUSED_SHOWN_NAME\n"
+          "import 'dart:async' show Future, Stream;");
     }
 
     // Make sure any other symbols in dart:core don't cause name conflicts with

--- a/lib/file_generator.dart
+++ b/lib/file_generator.dart
@@ -239,8 +239,7 @@ class FileGenerator extends ProtobufContainer {
     // We only add the dart:async import if there are generic client API
     // generators for services in the FileDescriptorProto.
     if (clientApiGenerators.isNotEmpty) {
-      out.println("// ignore: UNUSED_SHOWN_NAME\n"
-          "import 'dart:async' show Future, Stream;");
+      out.println(r"import 'dart:async' as $async;");
     }
 
     // Make sure any other symbols in dart:core don't cause name conflicts with
@@ -394,8 +393,8 @@ class FileGenerator extends ProtobufContainer {
     _writeHeading(out);
 
     if (serviceGenerators.isNotEmpty) {
-      out.println('''
-import 'dart:async';
+      out.println(r'''
+import 'dart:async' as $async;
 
 import 'package:protobuf/protobuf.dart';
 ''');
@@ -435,8 +434,8 @@ import 'package:protobuf/protobuf.dart';
     var out = new IndentingWriter();
     _writeHeading(out);
 
-    out.println('''
-import 'dart:async';
+    out.println(r'''
+import 'dart:async' as $async;
 
 import 'package:grpc/grpc.dart';
 ''');

--- a/lib/grpc_generator.dart
+++ b/lib/grpc_generator.dart
@@ -187,12 +187,14 @@ class _GrpcMethod {
     final requestType = service._getDartClassName(method.inputType);
     final responseType = service._getDartClassName(method.outputType);
 
-    final argumentType = clientStreaming ? 'Stream<$requestType>' : requestType;
+    final argumentType =
+        clientStreaming ? '\$async.Stream<$requestType>' : requestType;
     final clientReturnType = serverStreaming
         ? 'ResponseStream<$responseType>'
         : 'ResponseFuture<$responseType>';
-    final serverReturnType =
-        serverStreaming ? 'Stream<$responseType>' : 'Future<$responseType>';
+    final serverReturnType = serverStreaming
+        ? '\$async.Stream<$responseType>'
+        : '\$async.Future<$responseType>';
 
     return new _GrpcMethod._(
         grpcName,
@@ -221,8 +223,9 @@ class _GrpcMethod {
     out.addBlock(
         '$_clientReturnType $_dartName($_argumentType request, {CallOptions options}) {',
         '}', () {
-      final requestStream =
-          _clientStreaming ? 'request' : 'new Stream.fromIterable([request])';
+      final requestStream = _clientStreaming
+          ? 'request'
+          : r'new $async.Stream.fromIterable([request])';
       out.println(
           'final call = \$createCall(_\$$_dartName, $requestStream, options: options);');
       if (_serverStreaming) {
@@ -249,7 +252,7 @@ class _GrpcMethod {
     if (_clientStreaming) return;
 
     out.addBlock(
-        '$_serverReturnType ${_dartName}_Pre(ServiceCall call, Future request) async${_serverStreaming ? '*' : ''} {',
+        '$_serverReturnType ${_dartName}_Pre(ServiceCall call, \$async.Future request) async${_serverStreaming ? '*' : ''} {',
         '}', () {
       if (_serverStreaming) {
         out.println(

--- a/lib/service_generator.dart
+++ b/lib/service_generator.dart
@@ -132,7 +132,7 @@ class ServiceGenerator {
     var inputClass = _getDartClassName(m.inputType);
     var outputClass = _getDartClassName(m.outputType);
 
-    out.println('Future<$outputClass> $methodName('
+    out.println('\$async.Future<$outputClass> $methodName('
         'ServerContext ctx, $inputClass request);');
   }
 
@@ -159,7 +159,7 @@ class ServiceGenerator {
 
   void _generateDispatchMethod(out) {
     out.addBlock(
-        'Future<GeneratedMessage> handleCall(ServerContext ctx, '
+        r'$async.Future<GeneratedMessage> handleCall(ServerContext ctx, '
         'String method, GeneratedMessage request) {',
         '}', () {
       out.addBlock("switch (method) {", "}", () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: protoc_plugin
-version: 0.10.5-dev
+version: 0.10.5
 author: Dart Team <misc@dartlang.org>
 description: Protoc compiler plugin to generate Dart code
 homepage: https://github.com/dart-lang/dart-protoc-plugin

--- a/test/goldens/client
+++ b/test/goldens/client
@@ -2,11 +2,11 @@ class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  Future<SomeReply> aMethod($pb.ClientContext ctx, SomeRequest request) {
+  $async.Future<SomeReply> aMethod($pb.ClientContext ctx, SomeRequest request) {
     var emptyResponse = new SomeReply();
     return _client.invoke<SomeReply>(ctx, 'Test', 'AMethod', request, emptyResponse);
   }
-  Future<$0.AnotherReply> anotherMethod($pb.ClientContext ctx, $0.EmptyMessage request) {
+  $async.Future<$0.AnotherReply> anotherMethod($pb.ClientContext ctx, $0.EmptyMessage request) {
     var emptyResponse = new $0.AnotherReply();
     return _client.invoke<$0.AnotherReply>(ctx, 'Test', 'AnotherMethod', request, emptyResponse);
   }

--- a/test/goldens/grpc_service.pbgrpc
+++ b/test/goldens/grpc_service.pbgrpc
@@ -4,7 +4,7 @@
 ///
 // ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
 
-import 'dart:async';
+import 'dart:async' as $async;
 
 import 'package:grpc/grpc.dart';
 
@@ -33,12 +33,12 @@ class TestClient extends Client {
       : super(channel, options: options);
 
   ResponseFuture<Output> unary(Input request, {CallOptions options}) {
-    final call = $createCall(_$unary, new Stream.fromIterable([request]),
+    final call = $createCall(_$unary, new $async.Stream.fromIterable([request]),
         options: options);
     return new ResponseFuture(call);
   }
 
-  ResponseFuture<Output> clientStreaming(Stream<Input> request,
+  ResponseFuture<Output> clientStreaming($async.Stream<Input> request,
       {CallOptions options}) {
     final call = $createCall(_$clientStreaming, request, options: options);
     return new ResponseFuture(call);
@@ -46,12 +46,12 @@ class TestClient extends Client {
 
   ResponseStream<Output> serverStreaming(Input request, {CallOptions options}) {
     final call = $createCall(
-        _$serverStreaming, new Stream.fromIterable([request]),
+        _$serverStreaming, new $async.Stream.fromIterable([request]),
         options: options);
     return new ResponseStream(call);
   }
 
-  ResponseStream<Output> bidirectional(Stream<Input> request,
+  ResponseStream<Output> bidirectional($async.Stream<Input> request,
       {CallOptions options}) {
     final call = $createCall(_$bidirectional, request, options: options);
     return new ResponseStream(call);
@@ -92,16 +92,20 @@ abstract class TestServiceBase extends Service {
         (Output value) => value.writeToBuffer()));
   }
 
-  Future<Output> unary_Pre(ServiceCall call, Future request) async {
+  $async.Future<Output> unary_Pre(
+      ServiceCall call, $async.Future request) async {
     return unary(call, await request);
   }
 
-  Stream<Output> serverStreaming_Pre(ServiceCall call, Future request) async* {
+  $async.Stream<Output> serverStreaming_Pre(
+      ServiceCall call, $async.Future request) async* {
     yield* serverStreaming(call, (await request) as Input);
   }
 
-  Future<Output> unary(ServiceCall call, Input request);
-  Future<Output> clientStreaming(ServiceCall call, Stream<Input> request);
-  Stream<Output> serverStreaming(ServiceCall call, Input request);
-  Stream<Output> bidirectional(ServiceCall call, Stream<Input> request);
+  $async.Future<Output> unary(ServiceCall call, Input request);
+  $async.Future<Output> clientStreaming(
+      ServiceCall call, $async.Stream<Input> request);
+  $async.Stream<Output> serverStreaming(ServiceCall call, Input request);
+  $async.Stream<Output> bidirectional(
+      ServiceCall call, $async.Stream<Input> request);
 }

--- a/test/goldens/service.pb
+++ b/test/goldens/service.pb
@@ -4,7 +4,8 @@
 ///
 // ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
 
-import 'dart:async';
+// ignore: UNUSED_SHOWN_NAME
+import 'dart:async' show Future, Stream;
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
 

--- a/test/goldens/service.pb
+++ b/test/goldens/service.pb
@@ -4,8 +4,7 @@
 ///
 // ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
 
-// ignore: UNUSED_SHOWN_NAME
-import 'dart:async' show Future, Stream;
+import 'dart:async' as $async;
 // ignore: UNUSED_SHOWN_NAME
 import 'dart:core' show int, bool, double, String, List, override;
 
@@ -35,7 +34,7 @@ class TestApi {
   $pb.RpcClient _client;
   TestApi(this._client);
 
-  Future<Empty> ping($pb.ClientContext ctx, Empty request) {
+  $async.Future<Empty> ping($pb.ClientContext ctx, Empty request) {
     var emptyResponse = new Empty();
     return _client.invoke<Empty>(ctx, 'Test', 'Ping', request, emptyResponse);
   }

--- a/test/goldens/service.pbserver
+++ b/test/goldens/service.pbserver
@@ -4,7 +4,7 @@
 ///
 // ignore_for_file: non_constant_identifier_names,library_prefixes,unused_import
 
-import 'dart:async';
+import 'dart:async' as $async;
 
 import 'package:protobuf/protobuf.dart';
 
@@ -14,7 +14,7 @@ import 'test.pbjson.dart';
 export 'test.pb.dart';
 
 abstract class TestServiceBase extends GeneratedService {
-  Future<Empty> ping(ServerContext ctx, Empty request);
+  $async.Future<Empty> ping(ServerContext ctx, Empty request);
 
   GeneratedMessage createRequest(String method) {
     switch (method) {
@@ -23,7 +23,7 @@ abstract class TestServiceBase extends GeneratedService {
     }
   }
 
-  Future<GeneratedMessage> handleCall(ServerContext ctx, String method, GeneratedMessage request) {
+  $async.Future<GeneratedMessage> handleCall(ServerContext ctx, String method, GeneratedMessage request) {
     switch (method) {
       case 'Ping': return this.ping(ctx, request);
       default: throw new ArgumentError('Unknown method: $method');

--- a/test/goldens/serviceGenerator
+++ b/test/goldens/serviceGenerator
@@ -1,6 +1,6 @@
 abstract class TestServiceBase extends GeneratedService {
-  Future<SomeReply> aMethod(ServerContext ctx, SomeRequest request);
-  Future<$0.AnotherReply> anotherMethod(ServerContext ctx, $0.EmptyMessage request);
+  $async.Future<SomeReply> aMethod(ServerContext ctx, SomeRequest request);
+  $async.Future<$0.AnotherReply> anotherMethod(ServerContext ctx, $0.EmptyMessage request);
 
   GeneratedMessage createRequest(String method) {
     switch (method) {
@@ -10,7 +10,7 @@ abstract class TestServiceBase extends GeneratedService {
     }
   }
 
-  Future<GeneratedMessage> handleCall(ServerContext ctx, String method, GeneratedMessage request) {
+  $async.Future<GeneratedMessage> handleCall(ServerContext ctx, String method, GeneratedMessage request) {
     switch (method) {
       case 'AMethod': return this.aMethod(ctx, request);
       case 'AnotherMethod': return this.anotherMethod(ctx, request);


### PR DESCRIPTION
I had a message named `Zone` that was in conflict with `dart:async:Zone`